### PR TITLE
feat: Integrate Statuspage.io for bot and server status reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ S3_BUCKET=your_s3_bucket_name
 DISCORD_CHANNEL_ID=your_discord_channel_id
 DISCORD_TOKEN=your_discord_bot_token
 COMMAND_PREFIX=!
+
+# STATUSPAGE.IO
+STATUSPAGE_API_KEY=your_statuspage_api_key
+STATUSPAGE_PAGE_ID=your_statuspage_page_id
+STATUSPAGE_MINECRAFT_SERVER_COMPONENT_ID=your_minecraft_server_component_id
+STATUSPAGE_BOT_COMPONENT_ID=your_bot_component_id

--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ Copy `.env.example` to `.env` and configure:
 cp .env.example .env
 ```
 
+Fill in the following environment variables in your `.env` file:
+
+- `WORLD_NAME`: Name of your Minecraft world.
+- `SERVER_FP`: Filepath to the server directory.
+- `START_COMMAND`: The command used to start your Minecraft server (e.g., "java -Xms1024M -Xmx2G -jar server.jar nogui").
+- `RCON_IP`: RCON IP address and port (e.g., `0.0.0.0:25575`).
+- `RCON_PW`: Your RCON password.
+
+### AWS Configuration (Optional - for backups)
+- `S3_BUCKET`: Your S3 bucket name for world backups.
+
+### Discord Bot Configuration
+- `DISCORD_CHANNEL_ID`: The Discord channel ID where the bot should operate.
+- `DISCORD_TOKEN`: Your Discord bot token.
+- `COMMAND_PREFIX`: The prefix for bot commands (e.g., `!`).
+
+### Statuspage.io Integration (Optional)
+To enable Statuspage.io integration, you first need to obtain an API key and identify your Page ID and Component IDs from your Statuspage account.
+- `STATUSPAGE_API_KEY`: Your Statuspage API key.
+- `STATUSPAGE_PAGE_ID`: The ID of your Statuspage page.
+- `STATUSPAGE_MINECRAFT_SERVER_COMPONENT_ID`: The ID of the component on Statuspage representing your Minecraft server. The bot will update this component's status (e.g., Operational, Major Outage).
+- `STATUSPAGE_BOT_COMPONENT_ID`: The ID of the component on Statuspage representing the Discord bot itself. The bot will update this to Operational on startup and Major Outage on shutdown.
+
+If `STATUSPAGE_API_KEY` and `STATUSPAGE_PAGE_ID` are set, the bot will attempt to update component statuses. If the component IDs are not set, relevant updates will be skipped with a warning.
+
 ## Usage
 
 ### Discord Bot

--- a/bot/main.go
+++ b/bot/main.go
@@ -24,23 +24,62 @@ var (
 	channelID     string
 	commandPrefix byte
 	rconClient    *rcon.Conn
+
+	// Statuspage variables
+	statuspageAPIKey                 string
+	statuspagePageID                 string
+	statuspageMinecraftServerComponentID string
+	statuspageBotComponentID         string
+	spClient                         *StatuspageClient
 )
 
 func init() {
 	err := godotenv.Load("../.env") // Adjust the path as necessary
 	if err != nil {
 		fmt.Println("Error loading .env file")
-		return
+		// Attempt to run without .env for environments where vars are externally set
 	}
 
 	// Get environment variables
 	channelID = os.Getenv("DISCORD_CHANNEL_ID")
-	commandPrefix = os.Getenv("COMMAND_PREFIX")[0]
+	if channelID == "" {
+		fmt.Println("Warning: DISCORD_CHANNEL_ID is not set.")
+	}
+	commandPrefixStr := os.Getenv("COMMAND_PREFIX")
+	if commandPrefixStr == "" {
+		fmt.Println("Warning: COMMAND_PREFIX is not set. Defaulting to '!'")
+		commandPrefix = '!'
+	} else {
+		commandPrefix = commandPrefixStr[0]
+	}
+
+	// Statuspage environment variables
+	statuspageAPIKey = os.Getenv("STATUSPAGE_API_KEY")
+	statuspagePageID = os.Getenv("STATUSPAGE_PAGE_ID")
+	statuspageMinecraftServerComponentID = os.Getenv("STATUSPAGE_MINECRAFT_SERVER_COMPONENT_ID")
+	statuspageBotComponentID = os.Getenv("STATUSPAGE_BOT_COMPONENT_ID")
+
+	// Initialize Statuspage client
+	// We initialize it here so it can be used by various functions.
+	// Actual checks for API key presence for operations are done within the client methods.
+	spClient = NewStatuspageClient(statuspageAPIKey, statuspagePageID)
+
+	// Check essential Statuspage config and log warnings/errors
+	if err := checkStatuspageConfig(); err != nil {
+		fmt.Printf("Statuspage Configuration Error: %v\n", err)
+		// Decide if this should be a fatal error or just a warning.
+		// For now, let the bot run but Statuspage features might be disabled.
+	}
 }
 
 func main() {
+	discordToken := os.Getenv("DISCORD_TOKEN")
+	if discordToken == "" {
+		fmt.Println("Error: DISCORD_TOKEN is not set. Bot cannot start.")
+		return
+	}
 	// Create a new Discord session using the provided bot token.
-	dg, err := discordgo.New("Bot " + os.Getenv("DISCORD_TOKEN"))
+	dg, err := discordgo.New("Bot " + discordToken)
 	if err != nil {
 		fmt.Println("error creating Discord session,", err)
 		return
@@ -62,11 +101,41 @@ func main() {
 	// Start streaming server logs
 	go streamServerLogsToDiscord(dg, channelID, "../server/server.out")
 
+	// Update Bot component status to Operational on startup
+	if statuspageBotComponentID != "" {
+		err := spClient.UpdateComponentStatus(statuspageBotComponentID, StatusOperational)
+		if err != nil {
+			fmt.Printf("Failed to update bot status to operational on startup: %v\n", err)
+		} else {
+			fmt.Println("Bot status updated to operational on Statuspage.")
+		}
+	}
+
+	// Perform an initial Minecraft server status check and update Statuspage
+	// This uses the same logic as the periodic check.
+	// We pass nil for discordgo.Session and discordgo.MessageCreate as they are not needed for this initial check's Statuspage update.
+	go performMinecraftServerHealthCheck(nil, true) // Run immediately and then start ticker
+
+	// Start periodic health check for Minecraft server
+	go periodicMinecraftServerHealthCheck(dg)
+
+
 	// Wait here until CTRL-C or other term signal is received.
 	fmt.Println("Bot is now running.  Press CTRL-C to exit.")
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
+
+	// Update Bot component status to Major Outage on shutdown
+	if statuspageBotComponentID != "" {
+		fmt.Println("Bot shutting down. Updating Statuspage bot component to Major Outage...")
+		err := spClient.UpdateComponentStatus(statuspageBotComponentID, StatusMajorOutage)
+		if err != nil {
+			fmt.Printf("Failed to update bot status to major_outage on shutdown: %v\n", err)
+		} else {
+			fmt.Println("Bot status updated to major_outage on Statuspage.")
+		}
+	}
 
 	// Cleanly close down the Discord session.
 	dg.Close()
@@ -139,12 +208,28 @@ func checkMinecraftServerStatus(s *discordgo.Session, m *discordgo.MessageCreate
 	err := cmd.Run()
 
 	statusMsg := "Minecraft server is not running."
+	spStatus := StatusMajorOutage // Assume major outage unless proven otherwise
 
 	if err == nil { // If err is nil, it means a process was found
-		statusMsg = "Minecraft server is running."
+		// Further check with RCON if possible, to ensure it's not just a hung process
+		// For now, pgrep is the primary indicator for "running" vs "not running"
+		// A more nuanced check will be in the periodic goroutine
+		statusMsg = "Minecraft server is running (process found)."
+		spStatus = StatusOperational
 	}
 
 	s.ChannelMessageSend(channelID, statusMsg)
+
+	if statuspageMinecraftServerComponentID != "" {
+		updateErr := spClient.UpdateComponentStatus(statuspageMinecraftServerComponentID, spStatus)
+		if updateErr != nil {
+			errMsg := fmt.Sprintf("Failed to update Minecraft server status on Statuspage: %v", updateErr)
+			fmt.Println(errMsg)
+			s.ChannelMessageSend(channelID, "Error: "+errMsg) // Notify Discord as well
+		} else {
+			s.ChannelMessageSend(channelID, fmt.Sprintf("Minecraft server status on Statuspage updated to: %s", spStatus))
+		}
+	}
 }
 
 func startMinecraftServer(s *discordgo.Session, m *discordgo.MessageCreate) {
@@ -152,6 +237,18 @@ func startMinecraftServer(s *discordgo.Session, m *discordgo.MessageCreate) {
 		s.ChannelMessageSend(channelID, "START_COMMAND is not set in the environment")
 		return
 	}
+
+	// Check if server is already running
+	pgrepCmd := exec.Command("pgrep", "-f", "server.jar")
+	if pgrepCmd.Run() == nil {
+		s.ChannelMessageSend(channelID, "Minecraft server process appears to be already running.")
+		// Optionally, update statuspage to operational if not already
+		if statuspageMinecraftServerComponentID != "" {
+			spClient.UpdateComponentStatus(statuspageMinecraftServerComponentID, StatusOperational) // Best effort
+		}
+		return
+	}
+
 
 	cmdArgs := strings.Fields(os.Getenv("START_COMMAND"))
 	cmd := exec.Command("nohup", cmdArgs...)
@@ -169,10 +266,28 @@ func startMinecraftServer(s *discordgo.Session, m *discordgo.MessageCreate) {
 	err = cmd.Start()
 	if err != nil {
 		s.ChannelMessageSend(channelID, "Failed to start the Minecraft server: "+err.Error())
+		if statuspageMinecraftServerComponentID != "" {
+			updateErr := spClient.UpdateComponentStatus(statuspageMinecraftServerComponentID, StatusMajorOutage)
+			if updateErr != nil {
+				fmt.Printf("Failed to update Minecraft server status to major_outage on Statuspage after start failure: %v\n", updateErr)
+			}
+		}
 		return
 	}
 
 	s.ChannelMessageSend(channelID, "Minecraft server started.")
+	if statuspageMinecraftServerComponentID != "" {
+		// Give it a few seconds to actually start up before declaring operational
+		time.AfterFunc(5*time.Second, func() {
+			updateErr := spClient.UpdateComponentStatus(statuspageMinecraftServerComponentID, StatusOperational)
+			if updateErr != nil {
+				fmt.Printf("Failed to update Minecraft server status to operational on Statuspage: %v\n", updateErr)
+				// Consider sending a Discord message here too if important
+			} else {
+				fmt.Println("Minecraft server status updated to operational on Statuspage after start.")
+			}
+		})
+	}
 }
 
 func stopMinecraftServer(s *discordgo.Session, m *discordgo.MessageCreate) {
@@ -182,11 +297,121 @@ func stopMinecraftServer(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	if err != nil {
 		s.ChannelMessageSend(channelID, "Failed to stop the Minecraft server: "+err.Error())
+		// Potentially update statuspage to an error state or leave as is if unsure
 		return
 	}
 
 	s.ChannelMessageSend(channelID, "Minecraft server stopped.")
+	if statuspageMinecraftServerComponentID != "" {
+		updateErr := spClient.UpdateComponentStatus(statuspageMinecraftServerComponentID, StatusMajorOutage) // Or StatusUnderMaintenance if preferred for intentional stops
+		if updateErr != nil {
+			fmt.Printf("Failed to update Minecraft server status to major_outage on Statuspage after stop: %v\n", updateErr)
+		} else {
+			fmt.Println("Minecraft server status updated to major_outage on Statuspage after stop.")
+		}
+	}
 }
+
+// performMinecraftServerHealthCheck checks the Minecraft server's health and updates Statuspage.
+// If s is not nil, it can also send messages to Discord.
+// `initialCheck` is true if this is the first check on bot startup.
+func performMinecraftServerHealthCheck(s *discordgo.Session, initialCheck bool) {
+	if statuspageMinecraftServerComponentID == "" {
+		if !initialCheck && s != nil { // Avoid logging this on every tick if not configured
+			// fmt.Println("Minecraft Server Component ID for Statuspage is not set. Skipping health check for Statuspage.")
+		}
+		return // No component ID to update
+	}
+
+	currentStatus := StatusMajorOutage // Default to major outage
+
+	// 1. Check if server process is running
+	pgrepCmd := exec.Command("pgrep", "-f", "server.jar")
+	pgrepErr := pgrepCmd.Run()
+
+	if pgrepErr == nil { // Process found
+		// 2. Check RCON connection and a simple command
+		// Ensure RCON client is connected, attempt to connect if not
+		if rconClient == nil || rconClient.RemoteAddr().String() == "" { // Second check for truly closed client
+			var tempSession *discordgo.Session
+			if s != nil {
+				tempSession = s // Use existing session if available
+			} else {
+				// Create a temporary minimal session if needed for connectRcon, though connectRcon doesn't strictly use it for sending messages on initial failure path
+				// This path is mainly for the initial check where 's' might be nil.
+				// connectRcon will print to console if it fails and s is nil.
+			}
+			rconClient = connectRcon(tempSession) // connectRcon handles its own nil session checks for messaging
+		}
+
+		if rconClient != nil {
+			_, err := rconClient.Execute("list") // A simple command to check responsiveness
+			if err == nil {
+				currentStatus = StatusOperational
+			} else {
+				currentStatus = StatusDegradedPerformance // Process running, but RCON failing
+				if s != nil { // Only log to Discord if a session is available (not initial silent check)
+					s.ChannelMessageSend(channelID, fmt.Sprintf("Warning: Minecraft server process is running, but RCON is unresponsive: %v", err))
+				}
+				fmt.Printf("RCON command failed during health check: %v\n", err)
+				// Attempt to close and nullify rconClient so it's fresh for the next attempt
+				rconClient.Close()
+				rconClient = nil
+			}
+		} else {
+			currentStatus = StatusDegradedPerformance // Process running, but RCON couldn't connect
+			if s != nil {
+				s.ChannelMessageSend(channelID, "Warning: Minecraft server process is running, but RCON connection failed.")
+			}
+			fmt.Println("RCON client is nil during health check after attempting connection.")
+		}
+	} else {
+		currentStatus = StatusMajorOutage // Process not found
+		if rconClient != nil { // Ensure RCON client is closed if server process is gone
+			rconClient.Close()
+			rconClient = nil
+		}
+	}
+
+	// Update Statuspage
+	err := spClient.UpdateComponentStatus(statuspageMinecraftServerComponentID, currentStatus)
+	if err != nil {
+		errMsg := fmt.Sprintf("Periodic Health Check: Failed to update Minecraft server status on Statuspage to %s: %v", currentStatus, err)
+		fmt.Println(errMsg)
+		if s != nil { // Send to Discord if session available
+			s.ChannelMessageSend(channelID, "Error: "+errMsg)
+		}
+	} else {
+		if !initialCheck { // Don't be too verbose on the very first check's success
+			fmt.Printf("Periodic Health Check: Minecraft server status on Statuspage updated to: %s\n", currentStatus)
+			if s != nil && (currentStatus == StatusDegradedPerformance || currentStatus == StatusMajorOutage) {
+				// Notify on Discord if status is bad and it's not the initial check
+				s.ChannelMessageSend(channelID, fmt.Sprintf("Alert: Minecraft server status on Statuspage set to: %s", currentStatus))
+			}
+		} else {
+			fmt.Printf("Initial Health Check: Minecraft server status on Statuspage set to: %s\n", currentStatus)
+		}
+	}
+}
+
+func periodicMinecraftServerHealthCheck(s *discordgo.Session) {
+	if statuspageMinecraftServerComponentID == "" {
+		fmt.Println("STATUSPAGE_MINECRAFT_SERVER_COMPONENT_ID not set. Periodic health check for Statuspage will not run.")
+		return
+	}
+
+	// Check more frequently at first, then less frequently.
+	// For example, every 30 seconds for 5 minutes, then every 2 minutes.
+	// This is a simple example: check every 60 seconds.
+	// Statuspage rate limit is 1 req/sec.
+	ticker := time.NewTicker(60 * time.Second) // Check every 60 seconds
+	defer ticker.Stop()
+
+	for range ticker.C {
+		performMinecraftServerHealthCheck(s, false)
+	}
+}
+
 
 // sendLongMessage splits long messages into chunks and sends them
 func sendLongMessage(s *discordgo.Session, channelID, message string) {

--- a/bot/statuspage.go
+++ b/bot/statuspage.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	statuspageAPIBaseURL = "https://api.statuspage.io/v1"
+	// Component Statues
+	StatusOperational         = "operational"
+	StatusUnderMaintenance    = "under_maintenance"
+	StatusDegradedPerformance = "degraded_performance"
+	StatusPartialOutage       = "partial_outage"
+	StatusMajorOutage         = "major_outage"
+)
+
+// StatuspageClient holds the configuration for the Statuspage API client
+type StatuspageClient struct {
+	apiKey     string
+	pageID     string
+	httpClient *http.Client
+}
+
+// NewStatuspageClient creates a new client for Statuspage API interactions
+func NewStatuspageClient(apiKey, pageID string) *StatuspageClient {
+	return &StatuspageClient{
+		apiKey: apiKey,
+		pageID: pageID,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// ComponentUpdatePayload is the structure for updating a component's status
+type ComponentUpdatePayload struct {
+	Component struct {
+		Status string `json:"status"`
+	} `json:"component"`
+}
+
+// UpdateComponentStatus updates the status of a given component on Statuspage.io
+func (c *StatuspageClient) UpdateComponentStatus(componentID string, status string) error {
+	if c.apiKey == "" || c.pageID == "" || componentID == "" {
+		// Silently return if configuration is missing, error will be logged at bot startup/initialization.
+		// This prevents spamming logs if the bot is running without full Statuspage config.
+		return fmt.Errorf("Statuspage client not configured (API Key, Page ID, or Component ID missing). Cannot update component %s", componentID)
+	}
+
+	payload := ComponentUpdatePayload{}
+	payload.Component.Status = status
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Statuspage payload: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/pages/%s/components/%s.json", statuspageAPIBaseURL, c.pageID, componentID)
+
+	req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("failed to create Statuspage request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "OAuth "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request to Statuspage: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		fmt.Printf("Successfully updated Statuspage component %s to %s\n", componentID, status)
+		return nil
+	}
+
+	// Attempt to read body for more error info, but don't fail if that's not possible
+	var responseBody bytes.Buffer
+	_, _ = responseBody.ReadFrom(resp.Body)
+	errMsg := fmt.Sprintf("failed to update Statuspage component %s, status: %s, response: %s", componentID, resp.Status, responseBody.String())
+	fmt.Println("Statuspage API Error:", errMsg) // Log to console
+	return fmt.Errorf(errMsg)
+}
+
+// Helper function to validate essential Statuspage configuration on startup
+func checkStatuspageConfig() error {
+	if statuspageAPIKey == "" {
+		return fmt.Errorf("STATUSPAGE_API_KEY is not set")
+	}
+	if statuspagePageID == "" {
+		return fmt.Errorf("STATUSPAGE_PAGE_ID is not set")
+	}
+	// Component IDs can be checked where they are used, as one might be set and not the other.
+	// For example, user might only want to report server status and not bot status.
+	if statuspageMinecraftServerComponentID == "" && statuspageBotComponentID == "" {
+		fmt.Println("Warning: Neither STATUSPAGE_MINECRAFT_SERVER_COMPONENT_ID nor STATUSPAGE_BOT_COMPONENT_ID are set. Statuspage updates will be limited.")
+	} else {
+		if statuspageMinecraftServerComponentID == "" {
+			fmt.Println("Warning: STATUSPAGE_MINECRAFT_SERVER_COMPONENT_ID is not set. Minecraft server status will not be reported to Statuspage.")
+		}
+		if statuspageBotComponentID == "" {
+			fmt.Println("Warning: STATUSPAGE_BOT_COMPONENT_ID is not set. Bot status will not be reported to Statuspage.")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This commit introduces integration with Statuspage.io to report the operational status of the Discord bot and the Minecraft server.

Key changes:
- Added a Statuspage client (`bot/statuspage.go`) to interact with the Statuspage API (v1) for updating component statuses.
- Introduced new environment variables for Statuspage configuration: `STATUSPAGE_API_KEY`, `STATUSPAGE_PAGE_ID`, `STATUSPAGE_MINECRAFT_SERVER_COMPONENT_ID`, `STATUSPAGE_BOT_COMPONENT_ID`.
- Updated `bot/main.go`:
  - The bot now reports its own status as 'operational' on startup and 'major_outage' on shutdown to a configured Statuspage component.
  - Minecraft server status is reported to a configured Statuspage component based on:
    - `!start` command: sets to 'operational' (after a delay).
    - `!stop` command: sets to 'major_outage'.
    - `!status` command: updates based on pgrep check.
    - A new periodic health check goroutine that uses pgrep and RCON responsiveness to determine server status ('operational', 'degraded_performance', 'major_outage') and updates Statuspage accordingly (default every 60s).
  - Enhanced logging for Statuspage API interactions and configuration checks.
- Updated `.env.example` and `README.md` to include the new Statuspage configuration variables and documentation for the feature.